### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ google-crc32c==1.5.0
 google-resumable-media==2.7.2
 googleapis-common-protos==1.63.2
 grpc-google-iam-v1==0.13.1
-grpcio==1.64.1
+grpcio>=1.64.1,<=1.65.4
 grpcio-status==1.65.4
 h11==0.14.0
 httpcore==1.0.5


### PR DESCRIPTION
fixes [conficting grpcio-status and grpcio versions](https://github.com/pybites/pdm-llm-demo/issues/1)
allowed for grpcio version up to 1.65.4

grpcio>=1.64.1,<=1.65.4